### PR TITLE
relax versioning of @hotwired/turbo-rails

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "homepage": "https://github.com/cmer/ultimate_turbo_modal-npm#readme",
   "dependencies": {
     "@hotwired/stimulus": "^3.2.2",
-    "@hotwired/turbo-rails": "^7.3.0",
+    "@hotwired/turbo-rails": ">= 7.3.0",
     "el-transition": "^0.0.7"
   },
   "devDependencies": {


### PR DESCRIPTION
Ran into an issue trying to upgrade my project to turbo 8. I've got a custom confirm method (`Turbo.setConfirmMethod`) which uses sweetalert2 instead of the browsers default confirm dialog. 

After upgrading to turbo 8, I noticed that the confirm dialogs reverted back to the browser default. As this package is fixed to ^7.3.0 it appears to install it along side turbo 8 and cause this issue. I confirmed by removing this lib temporarily and opening my custom confirm dialog.

A workaround I currently have in place is to add an override to the package.json (I use npm - not yarn):

```
  "overrides": {
    "@hotwired/turbo-rails": "^8.0.2"
  },
```

I'm guessing if we just change "^7.3.0" to ">= 7.3.0" it shoud resolve this issue. Just going off another lib I use which also has this as a dependency [turbo_boost-commands](https://github.com/hopsoft/turbo_boost-commands/blob/main/package.json#L21C6-L21C33).
